### PR TITLE
Fix adot-instrument import error

### DIFF
--- a/sample-apps/python-lambda/aws_observability/aws_observability_sdk/aws_observability.py
+++ b/sample-apps/python-lambda/aws_observability/aws_observability_sdk/aws_observability.py
@@ -3,13 +3,13 @@ import logging
 from opentelemetry import trace
 from importlib import import_module
 
-from opentelemetry.sdk.extension.aws.trace import AwsXRayIdsGenerator
+from opentelemetry.sdk.extension.aws.trace import AwsXRayIdGenerator
 
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
-    SimpleExportSpanProcessor,
-    BatchExportSpanProcessor,
+    SimpleSpanProcessor,
+    BatchSpanProcessor,
 )
 
 from opentelemetry.resource import AwsLambdaResourceDetector
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 resource = Resource.create().merge(AwsLambdaResourceDetector().detect())
 trace.set_tracer_provider(
     TracerProvider(
-        ids_generator=AwsXRayIdsGenerator(),
+        id_generator=AwsXRayIdGenerator(),
         resource=resource,
     )
 )
@@ -34,16 +34,16 @@ if not console_exporter is None:
     from opentelemetry.sdk.trace.export import ConsoleSpanExporter
 
     trace.get_tracer_provider().add_span_processor(
-        SimpleExportSpanProcessor(ConsoleSpanExporter())
+        SimpleSpanProcessor(ConsoleSpanExporter())
     )
     logger.info("Console exporter initialized.")
 
 ci = os.environ.get("_ADOT_CI", None)
 if ci is None:
-    from opentelemetry.exporter.otlp.trace_exporter import OTLPSpanExporter
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 
     otlp_exporter = OTLPSpanExporter(endpoint="localhost:55680", insecure=True)
-    span_processor = BatchExportSpanProcessor(otlp_exporter)
+    span_processor = BatchSpanProcessor(otlp_exporter)
     trace.get_tracer_provider().add_span_processor(span_processor)
     logger.info("Otlp exporter initialized.")
 

--- a/sample-apps/python-lambda/aws_observability/aws_observability_sdk/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/sample-apps/python-lambda/aws_observability/aws_observability_sdk/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -54,7 +54,6 @@ from wrapt import wrap_function_wrapper
 from opentelemetry.sdk.extension.aws.trace.propagation.aws_xray_format import (
     AwsXRayFormat,
 )
-from opentelemetry.trace.propagation.textmap import DictGetter
 from opentelemetry.instrumentation.aws_lambda.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
@@ -97,9 +96,7 @@ class AwsLambdaInstrumentor(BaseInstrumentor):
         function_version = os.environ.get("AWS_LAMBDA_FUNCTION_VERSION")
 
         propagator = AwsXRayFormat()
-        parent_context = propagator.extract(
-            DictGetter(), {"X-Amzn-Trace-Id": xray_trace_id}
-        )
+        parent_context = propagator.extract({"X-Amzn-Trace-Id": xray_trace_id})
 
         with self._tracer.start_as_current_span(
             orig_handler, context=parent_context, kind=SpanKind.CONSUMER


### PR DESCRIPTION
**Description:**
Fixing a bug - Generated lambda layer from the latest source of this repo gives **Unable to import module `aws_observability`: cannot import name `AwsXRayIdsGenerator`** error which causes failure to generate XRay data.

Renamed `AwsXRayIdsGenerator` to `AwsXRayIdGenerator` as it was renamed in latest version of [opentelemetry-sdk-extension-aws](https://pypi.org/project/opentelemetry-sdk-extension-aws/) . Fixing `AwsXRayIdGenerator` import revealed some more name changes i.e. (`SimpleExportSpanProcessor`, `BatchExportSpanProcessor`, `OTLPSpanExporter` path, `AwsXRayFormat.extract` method signature). So, fixed all these names to reflect the latest changes of [opentelemetry-sdk](https://pypi.org/project/opentelemetry-sdk/)

**Link to tracking Issue:** https://github.com/aws-observability/aws-otel-lambda/issues/21

**Testing:** 

Deploy the sample app by running `cd sample-apps/python-lambda && ./run.sh` command ([documenation](https://github.com/aws-observability/aws-otel-lambda/blob/main/sample-apps/python-lambda/README.md)). Invoking the API endpoint provided by the sample app will generate XRay data.